### PR TITLE
Fix for 2019.4 LTS

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,6 +15,7 @@
     "com.unity.modules.director": "1.0.0",
     "com.unity.modules.imgui": "1.0.0",
     "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.modules.particlesystem": "1.0.0",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.screencapture": "1.0.0",
     "com.unity.modules.ui": "1.0.0",


### PR DESCRIPTION
When opening the project with Unity 2019.4 LTS, due to a change of Package Manager in 2019.4.3, the Timeline package causes a compilation error with the following message.

> Library\PackageCache\com.unity.timeline@1.3.0\Runtime\Playables\ParticleControlPlayable.cs(25,91): error CS0246: The type or namespace name 'ParticleSystem' could not be found (are you missing a using directive or an assembly reference?)

The project must have an explicit dependency on the build-in particle system package to avoid this error.